### PR TITLE
chore: Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm as bookworm
+FROM debian:bookworm AS bookworm
 ARG PHP_VERSION=8.4.4
 ARG ONIGURUMA_VERSION=6.9.10
 ARG LIBXML_VERSION=2.13.5


### PR DESCRIPTION
Avoids this annoying log noise

>  1 warning found (use docker --debug to expand):
>  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)

I know this is a minor thing, but it was a bug-bear.