### PR TITLE
Specify cross compilation target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV LIBXML_CFLAGS="-I/local/install/include/libxml2"
 
 # Configure PHP
 RUN cd php-src && \
-	emconfigure ./configure --enable-embed=static \
+	emconfigure ./configure --host=$(emcc -dumpmachine) --enable-embed=static \
 	--disable-all --without-pcre-jit --disable-fiber-asm --disable-cgi --disable-cli --disable-phpdbg \
 	--with-libxml --enable-simplexml --enable-xml --enable-xmlreader --enable-xmlwriter --enable-dom \
 	--enable-mbstring \


### PR DESCRIPTION
The PHP configure script makes decisions based on the target CPU (e.g. whether to enable JIT). When cross compiling we need to specify which host-system we are building for, with `--host=`, otherwise the configure script assumes it's the same as the build machine.

emconfigure doesn't pass `--host` automatically.

`--host` affects variables such as `$host_cpu`. We inspect this variable as least to determine whether to enable JIT: https://github.com/php/php-src/blob/98e0dbcefedeecf5e4d032e54df1aeebaa118754/ext/opcache/config.m4#L26-L30. When not passing `--host`, JIT may be enabled when the target is not supported, which fails later: https://github.com/php/php-src/blob/98e0dbcefedeecf5e4d032e54df1aeebaa118754/ext/opcache/jit/zend_jit.h#L29.

Along with https://github.com/php/php-src/pull/19350, this fixes the build for alpha4.